### PR TITLE
Images for agent version 2.181.2

### DIFF
--- a/2.170.1-wakatipu/Dockerfile
+++ b/2.170.1-wakatipu/Dockerfile
@@ -15,7 +15,7 @@ ENV HELM_VERSION=3.6.3
 ENV JFROGCLI_VERSION=2
 ENV JDK_VERSION=11.0.12.7.1
 ENV JRE_VERSION=${JDK_VERSION}
-ENV MAVEN_VERSION=3.8.2
+ENV MAVEN_VERSION=3.8.3
 
 # Agent capabilities (and aliases)
 ENV Docker=${DOCKER_VERSION}
@@ -103,7 +103,7 @@ RUN JFROGDIR=${Agent_ToolsDirectory}/_jfrog/current; \
 
 
 # Install Maven
-RUN curl -o maven.tar.gz -LO https://apache.inspire.net.nz/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+RUN curl -o maven.tar.gz -LO https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
      && tar -zxvf maven.tar.gz \
      && mkdir /usr/local/maven \
      && mv apache-maven-${MAVEN_VERSION} /usr/local/maven/${MAVEN_VERSION} \

--- a/2.181.2-wakatipu/Dockerfile
+++ b/2.181.2-wakatipu/Dockerfile
@@ -1,0 +1,118 @@
+
+FROM deltics/azdevops-buildagent:2.181.2
+
+LABEL author="Jolyon Direnko-Smith"
+LABEL description="Adds Docker binaries, dotnet sdk, GitVersion, GoLang, Helm, JDK, JFrog Cli, Maven"
+LABEL version="1.0"
+
+# Software versions installed
+ENV DOCKER_VERSION=20.10.8
+ENV DOTNET_VERSION=5.0
+ENV GCC_VERSION=11
+ENV GITVERSIONTOOL_VERSION=5.6.6
+ENV GO_VERSION=1.16.7
+ENV HELM_VERSION=3.6.3
+ENV JFROGCLI_VERSION=2
+ENV JDK_VERSION=11.0.12.7.1
+ENV JRE_VERSION=${JDK_VERSION}
+ENV MAVEN_VERSION=3.8.3
+
+# Agent capabilities (and aliases)
+ENV Docker=${DOCKER_VERSION}
+ENV DotNet=${DOTNET_VERSION}
+ENV DotNetSdk=${DOTNET_VERSION}
+ENV DotNetCore=${DOTNET_VERSION}
+ENV DotNetCoreSdk=${DOTNET_VERSION}
+ENV DotNetFramework=${DOTNET_VERSION}
+ENV DotNetFrameworkSdk=${DOTNET_VERSION}
+ENV Gcc=${GCC_VERSION}
+ENV GnuC=${GCC_VERSION}
+ENV GitVersion=${GITVERSIONTOOL_VERSION}
+ENV Go=${GO_VERSION}
+ENV GoLang=${GO_VERSION}
+ENV Helm=${HELM_VERSION}
+ENV JFrogCli=${JFROGCLI_VERSION}
+ENV Java=${JRE_VERSION}
+ENV JavaRuntimeEnvironment=${JRE_VERSION}
+ENV Jdk=${JDK_VERSION}
+ENV Jre=${JRE_VERSION}
+ENV Maven=${MAVEN_VERSION}
+ENV Mvn=${MAVEN_VERSION}
+
+
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
+# Add Microsoft package signing key to trusted keys (to allow installation of .net sdk)
+RUN curl -o packages-microsoft-prod.deb -L https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
+     && dpkg -i packages-microsoft-prod.deb \
+     && rm packages-microsoft-prod.deb
+
+# Install dotnet 5.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    dotnet-sdk-$DOTNET_VERSION
+
+# Add dotnet tools to path
+ENV PATH=$PATH:~/.dotnet/tools
+
+
+# Install GitVersion (using dotnet tool install)
+RUN dotnet tool install --global --version $GITVERSIONTOOL_VERSION GitVersion.Tool
+
+
+# Download Docker binaries
+RUN curl -o docker.tgz -L https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz \
+     && tar -zxvf docker.tgz --directory /usr/local \
+     && rm docker.tgz
+ENV PATH=$PATH:/usr/local/docker
+
+
+# Install GoLang
+RUN curl -o go.tgz -L https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz \
+     && tar xzvf go.tgz --directory /usr/local \
+     && rm go.tgz
+ENV PATH=$PATH:/usr/local/go/bin
+
+
+# Install Helm
+RUN curl -o helm.tar.gz -LsS https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -zxvf helm.tar.gz \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -f -R linux-amd64 \
+    && rm helm.tar.gz
+
+
+# Install JDK
+RUN curl -o jdk.tar.gz -LO https://corretto.aws/downloads/resources/${JDK_VERSION}/amazon-corretto-${JDK_VERSION}-linux-x64.tar.gz \ 
+     && tar -zxvf jdk.tar.gz \
+     && mv amazon-corretto-${JDK_VERSION}-linux-x64 jdk \
+     && mkdir /usr/local/bin/jdk \
+     && mv jdk /usr/local/bin/jdk/11.0.12.7.1 \
+     && rm jdk.tar.gz
+ENV JAVA_HOME=/usr/local/bin/jdk/11.0.12.7.1
+
+
+# Install JFrog Cli
+RUN JFROGDIR=${Agent_ToolsDirectory}/_jfrog/current; \
+     mkdir -p $JFROGDIR; \
+     curl -fLsS https://getcli.jfrog.io | bash -s v2; \
+     mv jfrog $JFROGDIR
+
+
+# Install Maven
+RUN curl -o maven.tar.gz -LO https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+     && tar -zxvf maven.tar.gz \
+     && mkdir /usr/local/maven \
+     && mv apache-maven-${MAVEN_VERSION} /usr/local/maven/${MAVEN_VERSION} \
+     && rm maven.tar.gz
+ENV PATH=$PATH:/usr/local/maven/${MAVEN_VERSION}/bin
+
+
+# Install gcc and header files (NOTE: renaming gcc-11 hardlink as gcc)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc-$GCC_VERSION \
+    libc6-dev
+RUN mv /usr/bin/gcc-11 /usr/bin/gcc

--- a/2.181.2/Dockerfile
+++ b/2.181.2/Dockerfile
@@ -1,0 +1,33 @@
+FROM deltics/azdevops-buildagent:base
+ARG TARGETARCH=amd64
+
+# Set shell for RUN commands
+SHELL ["/bin/bash", "--login", "-c"]
+
+
+# Versions of software introduced in this image
+ENV AGENT_VERSION=2.181.2
+
+
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
+
+# Download and run the installer for a Debian based build agent of the required version
+WORKDIR /azp
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      AZP_AGENTPACKAGE_URL=https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/vsts-agent-linux-x64-${AGENT_VERSION}.tar.gz; \
+    else \
+      AZP_AGENTPACKAGE_URL=https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/vsts-agent-linux-$TARGETARCH-${AGENT_VERSION}.tar.gz; \
+    fi; \
+    curl -LsS "${AZP_AGENTPACKAGE_URL}" | tar -xz
+
+COPY ./start.sh .
+RUN chmod +x start.sh
+
+RUN mkdir -p /azp/_work/_tool
+ENV Agent_ToolsDirectory=/azp/_work/_tool
+
+ENTRYPOINT [ "./start.sh" ]

--- a/2.181.2/start.sh
+++ b/2.181.2/start.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+if [ -z "$AZP_URL" ]; then
+  echo 1>&2 "error: missing AZP_URL environment variable"
+  exit 1
+fi
+
+if [ -z "$AZP_TOKEN_FILE" ]; then
+  if [ -z "$AZP_TOKEN" ]; then
+    echo 1>&2 "error: missing AZP_TOKEN environment variable"
+    exit 1
+  fi
+
+  AZP_TOKEN_FILE=/azp/.token
+  echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
+fi
+
+unset AZP_TOKEN
+
+if [ -n "$AZP_WORK" ]; then
+  mkdir -p "$AZP_WORK"
+fi
+
+export AGENT_ALLOW_RUNASROOT="1"
+
+cleanup() {
+  if [ -e config.sh ]; then
+    print_header "Cleanup. Removing Azure Pipelines agent..."
+
+    # If the agent has some running jobs, the configuration removal process will fail.
+    # So, give it some time to finish the job.
+    while true; do
+      ./config.sh remove --unattended --auth PAT --token $(cat "$AZP_TOKEN_FILE") && break
+
+      echo "Retrying in 30 seconds..."
+      sleep 30
+    done
+  fi
+}
+
+print_header() {
+  lightcyan='\033[1;36m'
+  nocolor='\033[0m'
+  echo -e "${lightcyan}$1${nocolor}"
+}
+
+# Let the agent ignore the token env variables
+export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE
+
+source ./env.sh
+
+print_header "1. Configuring Azure Pipelines agent..."
+
+./config.sh --unattended \
+  --agent "${AZP_AGENT_NAME:-$(hostname)}" \
+  --url "$AZP_URL" \
+  --auth PAT \
+  --token $(cat "$AZP_TOKEN_FILE") \
+  --pool "${AZP_POOL:-Default}" \
+  --work "${AZP_WORK:-_work}" \
+  --replace \
+  --acceptTeeEula & wait $!
+
+print_header "2. Running Azure Pipelines agent..."
+
+trap 'cleanup; exit 0' EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+# To be aware of TERM and INT signals call run.sh
+# Running it with the --once flag at the end will shut down the agent after the build is executed
+./run.sh "$@"

--- a/2.190.0-wakatipu/Dockerfile
+++ b/2.190.0-wakatipu/Dockerfile
@@ -15,7 +15,7 @@ ENV HELM_VERSION=3.6.3
 ENV JFROGCLI_VERSION=2
 ENV JDK_VERSION=11.0.12.7.1
 ENV JRE_VERSION=${JDK_VERSION}
-ENV MAVEN_VERSION=3.8.2
+ENV MAVEN_VERSION=3.8.3
 
 # Agent capabilities (and aliases)
 ENV Docker=${DOCKER_VERSION}
@@ -103,7 +103,7 @@ ENV JAVA_HOME=/usr/local/bin/jdk/11.0.12.7.1
 
 
 # Install Maven
-RUN curl -o maven.tar.gz -LO https://apache.inspire.net.nz/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+RUN curl -o maven.tar.gz -LO https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
      && tar -zxvf maven.tar.gz \
      && mkdir /usr/local/maven \
      && mv apache-maven-${MAVEN_VERSION} /usr/local/maven/${MAVEN_VERSION} \

--- a/README-wakatipu.md
+++ b/README-wakatipu.md
@@ -14,7 +14,7 @@ On top of the base layer, this layer adds:
 * Helm 3.6.3
 * JDK 11.0.12.7.1 (Amazon Corretto)
 * JFrog Cli v2
-* Maven 3.8.2
+* Maven 3.8.3
 
 
 ## Intended Use

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ The build agent in these containers is of limited use since the image includes o
 * Ubuntu 21.04 (base image)
 * Git 2.30.2
 * NVM 0.38
-* Node 16.6.2
+* Node 16.11.1
 * Azure Cli
 
 Tagged images are provided for the following versions of the build agent:
 
 * 2.170.1
+* 2.181.2
 * 2.190.0 (latest)
 
 The image tag corresponds to the agent version, so the full identifier for the 2.190.0 image is:
@@ -30,7 +31,7 @@ For additional information on more fully equipped agent images, refer to the doc
 
 | Tag | Short Tag | Overview |
 | --- | --------- | -------- |
-| [*&lt;agent-version&gt;*-docker20.10.8-dotnet5.0-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.2](README-wakatipu.md) | [&lt;agent-version&gt;-wakatipu](README-wakatipu.md) | Comprehensive tooling for building GoLang microservices in an enterprise context |
+| [*&lt;agent-version&gt;*-docker20.10.8-dotnet5.0-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.3](README-wakatipu.md) | [&lt;agent-version&gt;-wakatipu](README-wakatipu.md) | Comprehensive tooling for building GoLang microservices in an enterprise context |
 
 _NOTE: The links to documentation for the above image(s) are only functional when viewing this [README in the original source repo on GitHub](https://github.com/deltics/azdevops-buildagent/blob/master/README.md)_.
 

--- a/_base/Dockerfile
+++ b/_base/Dockerfile
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Versions of software introduced in this image
 ENV GIT_VERSION=2.30.2
 ENV NVM_VERSION=0.38.0
-ENV NODE_VERSION=16.6.2
+ENV NODE_VERSION=16.11.1
 
 # Environment variables (and aliases/synonyms) that identify Agent capabilities
 ENV Git=$GIT_VERSION

--- a/build.sh
+++ b/build.sh
@@ -4,12 +4,17 @@ docker build -t deltics/azdevops-buildagent:base _base
 
 # Build agent base images (different versions)
 docker build -t deltics/azdevops-buildagent:2.170.1 2.170.1
+docker build -t deltics/azdevops-buildagent:2.181.2 2.181.2
 docker build -t deltics/azdevops-buildagent:2.190.0 2.190.0
 
 # GoLang images
-docker build -t deltics/azdevops-buildagent:2.170.1-docker20.10.8-dotnet5.0-gcc11-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.2 2.170.1-wakatipu
-docker build -t deltics/azdevops-buildagent:2.190.0-docker20.10.8-dotnet5.0-gcc11-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.2 2.190.0-wakatipu
+contentTag="docker20.10.8-dotnet5.0-gcc11-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.3"
+
+docker build -t deltics/azdevops-buildagent:2.170.1-$contentTag 2.170.1-wakatipu
+docker build -t deltics/azdevops-buildagent:2.181.2-$contentTag 2.181.2-wakatipu
+docker build -t deltics/azdevops-buildagent:2.190.0-$contentTag 2.190.0-wakatipu
 
 # Short/alternate tags
 docker build -t deltics/azdevops-buildagent:2.170.1-wakatipu 2.170.1-wakatipu
+docker build -t deltics/azdevops-buildagent:2.181.2-wakatipu 2.181.2-wakatipu
 docker build -t deltics/azdevops-buildagent:2.190.0-wakatipu 2.190.0-wakatipu

--- a/push.sh
+++ b/push.sh
@@ -4,12 +4,17 @@ docker push deltics/azdevops-buildagent:base
 
 # Build agent base images (different versions)
 docker push deltics/azdevops-buildagent:2.170.1
+docker push deltics/azdevops-buildagent:2.181.2
 docker push deltics/azdevops-buildagent:2.190.0
 
 # GoLang images
-docker push deltics/azdevops-buildagent:2.170.1-docker20.10.8-dotnet5.0-gcc11-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.2
-docker push deltics/azdevops-buildagent:2.190.0-docker20.10.8-dotnet5.0-gcc11-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.2
+contentTag="docker20.10.8-dotnet5.0-gcc11-gitversion5.6.6-go1.16.7-helm3.6.3-jdk11-jfrog2-maven3.8.3"
+
+docker push deltics/azdevops-buildagent:2.170.1-docker20.10.8-$contentTag
+docker push deltics/azdevops-buildagent:2.181.2-docker20.10.8-$contentTag
+docker push deltics/azdevops-buildagent:2.190.0-docker20.10.8-$contentTag
 
 # Short/alternate tags
 docker push deltics/azdevops-buildagent:2.170.1-wakatipu
+docker push deltics/azdevops-buildagent:2.181.2-wakatipu
 docker push deltics/azdevops-buildagent:2.190.0-wakatipu

--- a/scan.sh
+++ b/scan.sh
@@ -4,4 +4,5 @@
 #  will be identified as such, if present.
 
 docker scan deltics/azdevops-buildagent:2.170.1-wakatipu
+docker scan deltics/azdevops-buildagent:2.181.2-wakatipu
 docker scan deltics/azdevops-buildagent:2.190.0-wakatipu


### PR DESCRIPTION
* Provides both basic and wakatipu images using version 2.181.2 of the agent software
* Updates all images to use Node 16.11.1 (to address vulns identified by snyk)