### PR TITLE
image updates

### DIFF
--- a/.build/build.sh
+++ b/.build/build.sh
@@ -29,23 +29,23 @@ function doBuild() {
 }
 
 # Installed in the "os" layer
-_git=2.32.0
-_nvm=0.38.0
+_git=2.34.1
+_nvm=0.39.1
 _node=16.11.1
 
 # ENV defined in the "env" layer, but installed in n.nnn.n agent layers
-_docker=20.10.8
-_dotnet=5.0
+_docker=20.10.18
+_dotnet=6.0
 _gcc=11
-_gitversionTool=5.8.1
-_go=1.17.3
+_gitversionTool=5.10.3
+_go=1.19.1
 _gojunit=0.9.1
-_goswagger=0.28.0
-_helm=3.6.3
+_goswagger=0.30.3
+_helm=3.10.0
 _jfrogcli=2
 _jdk=11.0.12.7.1
-_kubectl=1.22.4
-_maven=3.8.3
+_kubectl=1.22.15
+_maven=3.8.6
 
 # Update dockerfile(s)
 setENV  os/dockerfile  GIT   $_git

--- a/README-wakatipu.md
+++ b/README-wakatipu.md
@@ -8,17 +8,17 @@ On top of the base layer, this layer adds:
 
 | Component | Version | Notes |
 | -- | -- | -- |
-| Docker | 20.10.8 |
-| DotNet | 5.0 |
+| Docker | 20.10.18 |
+| DotNet | 6.0 |
 | gcc | 11 |
-| GitVersion | 5.8.1 |
-| GoLang | 1.17.3 |
-| GoSwagger | 0.28.0 |
-| Helm | 3.6.3 |
+| GitVersion | 5.10.3 |
+| GoLang | 1.19.1 |
+| GoSwagger | 0.30.3 |
+| Helm | 3.10.0 |
 | JDK | 11.0.12.7.1 |
 | JFrog | 2 |
-| kubectl | 1.22.4 |
-| Maven | 3.8.3 |
+| kubectl | 1.22.15 |
+| Maven | 3.8.6 |
 
 Additional GoLang Utilities
 | Utility | Version |

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The build agent in these images is of limited use since the image includes only 
 
 | Component | Version |
 | -- | -- |
-| git | 2.32.0 |
-| nvm | 0.38.0 |
+| git | 2.34.1 |
+| nvm | 0.39.1 |
 | node | 16.11.1 |
 | Azure Cli | |
 

--- a/os/dockerfile
+++ b/os/dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 # Metadata
 LABEL author="Jolyon Direnko-Smith"
@@ -8,8 +8,8 @@ LABEL description="An Ubuntu image providing a base for self-hosted Azure DevOps
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Versions of software introduced in this image
-ENV GIT_VERSION=2.32.0
-ENV NVM_VERSION=0.38.0
+ENV GIT_VERSION=2.34.1
+ENV NVM_VERSION=0.39.1
 ENV NODE_VERSION=16.11.1
 
 # Environment variables (and aliases/synonyms) that identify Agent capabilities
@@ -29,13 +29,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     jq \
-    git=1:$GIT_VERSION-1ubuntu1 \
+    git=1:$GIT_VERSION-1ubuntu1.4 \
     iputils-ping \
     libcurl4 \
-    libicu67 \
+    libicu70 \
     libunwind8 \
     netcat \
-    libssl1.1 \
+    libssl3 \
     libssh-4 \
   && rm -rf /var/lib/apt/lists/*
 

--- a/wakatipu/dockerfile
+++ b/wakatipu/dockerfile
@@ -9,18 +9,18 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 # The versions of software to be installed
 
-ENV DOCKER_VERSION=20.10.8
-ENV DOTNET_VERSION=5.0
+ENV DOCKER_VERSION=20.10.18
+ENV DOTNET_VERSION=6.0
 ENV GCC_VERSION=11
-ENV GITVERSIONTOOL_VERSION=5.8.1
-ENV GO_VERSION=1.17.3
-ENV GOSWAGGER_VERSION=0.28.0
-ENV HELM_VERSION=3.6.3
+ENV GITVERSIONTOOL_VERSION=5.10.3
+ENV GO_VERSION=1.19.1
+ENV GOSWAGGER_VERSION=0.30.3
+ENV HELM_VERSION=3.10.0
 ENV JFROGCLI_VERSION=2
 ENV JDK_VERSION=11.0.12.7.1
 ENV JRE_VERSION=${JDK_VERSION}
-ENV KUBECTL_VERSION=1.22.4
-ENV MAVEN_VERSION=3.8.3
+ENV KUBECTL_VERSION=1.22.15
+ENV MAVEN_VERSION=3.8.6
 
 # Agent capabilities (and aliases)
 
@@ -61,11 +61,6 @@ ENV Agent_ToolsDirectory=/azp/_work/_tool
 # configure apt to not require confirmation (assume the -y argument by default)
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
-
-# Add Microsoft package signing key to trusted keys (to allow installation of .net sdk)
-RUN curl -o packages-microsoft-prod.deb -L https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
-     && dpkg -i packages-microsoft-prod.deb \
-     && rm packages-microsoft-prod.deb
 
 # Install dotnet 5.0
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
updated to ubuntu 22.40 LTS base, plus:

- go 1.19.1
- dotnet 6.0

with latest:

- goswagger
- gitversion
- helm
- kubectl (1.22)
- maven
- nvm
- docker (cli)