### PR TITLE
update to node 16.17.1

### DIFF
--- a/.build/build.sh
+++ b/.build/build.sh
@@ -31,7 +31,7 @@ function doBuild() {
 # Installed in the "os" layer
 _git=2.34.1
 _nvm=0.39.1
-_node=16.11.1
+_node=16.17.1
 
 # ENV defined in the "env" layer, but installed in n.nnn.n agent layers
 _docker=20.10.18

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The build agent in these images is of limited use since the image includes only 
 | -- | -- |
 | git | 2.34.1 |
 | nvm | 0.39.1 |
-| node | 16.11.1 |
+| node | 16.17.1 |
 | Azure Cli | |
 
 Tagged images are provided for the following versions of the build agent:

--- a/os/dockerfile
+++ b/os/dockerfile
@@ -10,7 +10,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Versions of software introduced in this image
 ENV GIT_VERSION=2.34.1
 ENV NVM_VERSION=0.39.1
-ENV NODE_VERSION=16.11.1
+ENV NODE_VERSION=16.17.1
 
 # Environment variables (and aliases/synonyms) that identify Agent capabilities
 ENV Git=$GIT_VERSION


### PR DESCRIPTION
Addresses majority of vulnerabilities in image related to node version, whilst staying on node 16